### PR TITLE
fix(ci): WSL構成をflake出力に追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,5 +128,9 @@
       homeConfigurations.linux = mkLinuxHome {
         inherit username;
       };
+
+      homeConfigurations.wsl-work = mkWslWorkHome {
+        inherit username;
+      };
     };
 }


### PR DESCRIPTION
## 概要

WSL Docker CIが参照する `homeConfigurations.wsl-work` をルートのflake出力へ追加します。

## 原因

WSL Dockerテストは `homeConfigurations.wsl-work.activationPackage` をビルドしますが、ルートの `flake.nix` は `homeConfigurations.linux` のみを公開していたため、属性が見つからず失敗していました。

## 影響

`wsl-work` プロファイルのHome Manager activation packageをルートflakeから直接評価・ビルドできるようになります。

## 検証

- `nix eval --raw .#homeConfigurations.wsl-work.config.home.sessionVariables.BROWSER`
- `nix eval --raw .#homeConfigurations.wsl-work.activationPackage.drvPath`
- Bash構文チェック
- ShellCheck
- `scripts/test_open.sh`

実ビルドはローカルホストがaarch64-darwin、対象がx86_64-linuxのため、GitHub Actions上で確認します。
